### PR TITLE
SDC-9938. Azure DataLake fails while producing close events when max …

### DIFF
--- a/azure-lib/src/main/java/com/streamsets/pipeline/stage/destination/datalake/DataLakeTarget.java
+++ b/azure-lib/src/main/java/com/streamsets/pipeline/stage/destination/datalake/DataLakeTarget.java
@@ -329,7 +329,7 @@ public class DataLakeTarget extends BaseTarget {
       Record record = recordIterator.next();
 
       try {
-        Date recordTime = writer.getRecordTime(timeDriverEval, timeDriverVars, conf.timeDriver, record);
+        Date recordTime = ELUtils.getRecordTime(timeDriverEval, timeDriverVars, conf.timeDriver, record);
 
         if (recordTime == null) {
           LOG.error(Errors.ADLS_07.getMessage(), conf.timeDriver);

--- a/azure-lib/src/main/java/com/streamsets/pipeline/stage/destination/datalake/writer/RecordWriter.java
+++ b/azure-lib/src/main/java/com/streamsets/pipeline/stage/destination/datalake/writer/RecordWriter.java
@@ -171,22 +171,6 @@ public class RecordWriter {
     outputStreamHelper.clearStatus();
   }
 
-  public static Date getRecordTime(
-      ELEval elEvaluator,
-      ELVars variables,
-      String expression,
-      Record record
-  ) throws OnRecordErrorException {
-    try {
-      TimeNowEL.setTimeNowInContext(variables, new Date());
-      RecordEL.setRecordInContext(variables, record);
-      return elEvaluator.eval(variables, expression, Date.class);
-    } catch (ELEvalException e) {
-      LOG.error("Failed to evaluate expression '{}' : ", expression, e.toString(), e);
-      throw new OnRecordErrorException(record, e.getErrorCode(), e.getParams());
-    }
-  }
-
   public void flush(String filePath) throws IOException {
     DataLakeDataGenerator generator = generators.get(filePath);
     if (generator == null) {
@@ -272,7 +256,7 @@ public class RecordWriter {
   private void produceCloseFileEvent(String finalPath) throws IOException {
     ContentSummary summary = client.getContentSummary(finalPath);
     DataLakeEvents.CLOSED_FILE.create(context)
-        .with("filepath", finalPath.toString())
+        .with("filepath", finalPath)
         .with("filename", finalPath.substring(finalPath.lastIndexOf("/")+1))
         .with("length", summary.length)
         .createAndSend();


### PR DESCRIPTION
…record setting is enabled.

It looks like we have been calling both writer.close and clearStatus of which both apis were trying to rename the file, even though one succeeds another will fail (but the return status was a boolean), so we were trying to generate two close events. This is also because we were not clearing filePathCount state once we commit the file. This patch changes the logic to remove the dirPath from filePathCount when we commit and the dirPath will get automatically added the next time a file is created.

Change-Id: I42bb0dda6fa346ade709e254c2ad67c06285b8b7
Reviewed-on: https://review.streamsets.net/16522
Tested-by: StreamSets CI <streamsets-ci-spam@streamsets.com>
Reviewed-by: Jarcec Cecho <jarcec@streamsets.com>